### PR TITLE
Packet filtering

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -283,14 +283,6 @@ func setupRawConn(server *Server, client *Peer) *ipv4.RawConn {
 }
 
 func applyBPF(rawConn *ipv4.RawConn, server *Server, client *Peer) {
-
-	// WHAT WE KNOW
-	// - Filtering with just one jump works :)
-	//   - This applies to all options (src/dst port, src ip)
-
-	// WHAT WE WILL RESEARCH
-	// Can we chain the options by changing the numbers?
-
 	const ipv4HeaderLen = 20
 
 	const srcIPOffset = 12


### PR DESCRIPTION
Packets are filtered properly now :)

Previously, packets that weren't intended for this program were being "let in" to userspace. This was due to a faulty BPF program. Once I figured out what was going wrong, I fixed it, tested it (somewhat), and put it back together. Packets are filtered again, and the only notable changes were to the BPF code. Packets are still filtered by the kernel, saving us precious time.